### PR TITLE
Forward unrecognized flags to Claude Code

### DIFF
--- a/claude-pod
+++ b/claude-pod
@@ -130,7 +130,8 @@ cmd_run() {
                 [[ $# -lt 2 ]] && die "Flag --writable-dir requires a directory"
                 writable_dirs+=("$2"); shift 2 ;;
             --)              shift; claude_args=("$@"); break ;;
-            *)               claude_args=("$@"); break ;;
+            -*)              claude_args=("$@"); break ;;
+            *)               die "Unknown command: $1. See 'claude-pod --help'." ;;
         esac
     done
 
@@ -263,7 +264,6 @@ case "${1:-}" in
     exec)  shift; cmd_exec "$@" ;;
     ps)    shift; cmd_ps "$@" ;;
     clean) shift; cmd_clean "$@" ;;
-    --)  shift; cmd_run "$@" ;;
     -h|--help)
         cat <<'EOF'
 Usage: claude-pod [command] [options]


### PR DESCRIPTION
## Summary
- Unrecognized flags in `cmd_run` are now forwarded to Claude Code instead of causing an error
- `claude-pod -- -p "do something"` works at the top level (without `run`)
- `claude-pod -p "do something"` just works

Closes #6

## Test plan
- [x] `claude-pod -p "do something"` forwards `-p` to claude
- [x] `claude-pod -- --resume` works
- [x] `claude-pod --detach -- -p "foo"` still parses `--detach` as a claude-pod flag
- [x] `claude-pod run -- -p "foo"` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)