### PR TITLE
Add --keep-groups flag to preserve supplementary groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ claude-pod shell                    # drop into a shell in the container
 | `--network=none` | Disable networking |
 | `--notify <topic>` | [ntfy.sh](https://ntfy.sh) notification on exit |
 | `--notify-cmd <cmd>` | Custom exit command (`$WORKSPACE`, `$EXIT_CODE`) |
+| `--keep-groups` | Preserve supplementary groups (for shared dirs) |
 | `-wd, --writable-dir <path>` | Extra read-write mount (repeatable) |
 
 ## Config

--- a/claude-pod
+++ b/claude-pod
@@ -205,6 +205,7 @@ cmd_run() {
     require_image
 
     local detach=false
+    local keep_groups=false
     local network=""
     local notify_cmd=""
     local writable_dirs=()
@@ -229,6 +230,7 @@ cmd_run() {
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --detach)        detach=true; shift ;;
+            --keep-groups)   keep_groups=true; shift ;;
             --network=*)     network="${1#--network=}"; shift ;;
             --notify)
                 # Shorthand for ntfy.sh: --notify <topic>
@@ -264,6 +266,10 @@ cmd_run() {
         --security-opt label=disable
         -w "${cwd}"
     )
+
+    if $keep_groups; then
+        args+=(--group-add keep-groups)
+    fi
 
     mount_home_items args "$cwd" "${writable_dirs[*]}"
 
@@ -450,6 +456,7 @@ Run flags:
   --network=none       Disable all networking
   --notify <topic>     Send ntfy.sh notification when session ends
   --notify-cmd <cmd>   Run custom command on exit ($WORKSPACE, $EXIT_CODE)
+  --keep-groups        Preserve supplementary groups in container
   -wd, --writable-dir <path>
                        Mount a dir read-write (can be repeated)
 


### PR DESCRIPTION
## Summary
- Adds `--keep-groups` flag to `claude-pod run` that passes `--group-add keep-groups` to podman
- Preserves supplementary groups (e.g. `household`) inside the container so group-based file permissions work on shared directories

## Usage
```bash
claude-pod --keep-groups -wd /home/shared
```

## Test plan
- [ ] Run `claude-pod --keep-groups -wd /home/shared` and verify `id` inside the container shows supplementary groups
- [ ] Run without `--keep-groups` and verify groups show as `nobody` (existing behavior unchanged)
- [ ] Verify `claude-pod --help` shows the new flag

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)