### PR TITLE
Fix install --ref skipping download when already installed

### DIFF
--- a/claude-pod
+++ b/claude-pod
@@ -3,14 +3,27 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" 2>/dev/null && pwd)"
 
 # Bootstrap: when piped from curl (bash -s -- install), claude-pod.py won't
 # exist alongside this script. Download everything and hand off to Python.
-if [ "$1" = "install" ] && ! [ -f "$SCRIPT_DIR/claude-pod.py" ] && ! [ -f "${HOME}/.local/share/claude-pod/claude-pod.py" ]; then
-    # Parse --ref flag (default: main)
-    REF="main"
+# Pre-parse --ref so we can decide whether to skip the download.
+REF="main"
+if [ "$1" = "install" ]; then
+    for _arg in "$@"; do
+        case "$_prev" in
+            --ref) REF="$_arg"; break ;;
+        esac
+        case "$_arg" in
+            --ref=*) REF="${_arg#--ref=}"; break ;;
+            --ref) _prev="--ref" ;;
+        esac
+    done
+    unset _prev _arg
+fi
+
+if [ "$1" = "install" ] && { [ "$REF" != "main" ] || { ! [ -f "$SCRIPT_DIR/claude-pod.py" ] && ! [ -f "${HOME}/.local/share/claude-pod/claude-pod.py" ]; }; }; then
     shift # consume "install"
     while [ $# -gt 0 ]; do
         case "$1" in
-            --ref) REF="$2"; shift 2 ;;
-            --ref=*) REF="${1#--ref=}"; shift ;;
+            --ref) shift 2 ;;
+            --ref=*) shift ;;
             *) shift ;;
         esac
     done

--- a/claude-pod.py
+++ b/claude-pod.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     sys.exit("error: Python 3.11+ is required (for tomllib)")
 
-VERSION = "0.8.1"
+VERSION = "0.8.2"
 IMAGE = "claude-pod:latest"
 CONTAINER_NAME_PREFIX = "claude-pod"
 HOST_OS = platform.system()


### PR DESCRIPTION
## Summary
- When `claude-pod` is already installed, the bootstrap guard on line 6 skipped the entire download block — including `--ref` parsing. This meant `--ref` was silently ignored for existing installs.
- Moved `--ref` parsing before the guard check and allow re-download when ref is not `main`, so `curl ... | bash -s -- install --ref some-branch` always fetches from the specified ref.

Closes #45

## Test plan
- [ ] Fresh install (no existing files): `curl ... | bash -s -- install` downloads and installs
- [ ] Fresh install with ref: `curl ... | bash -s -- install --ref some-branch` downloads from the branch
- [ ] Existing install, no ref: `curl ... | bash -s -- install` skips download (unchanged behavior)
- [ ] Existing install with ref: `curl ... | bash -s -- install --ref some-branch` re-downloads from the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)