### PR TITLE
feat: mount /tmp and package caches as read-write (#47)

### DIFF
--- a/claude-pod.bash
+++ b/claude-pod.bash
@@ -9,7 +9,7 @@ fi
 
 set -euo pipefail
 
-VERSION="0.8.1"
+VERSION="0.9.0"
 IMAGE="claude-pod:latest"
 CONFIG_FILE="${HOME}/.config/claude-pod/config.toml"
 PROJECT_CONFIG=""  # set to CWD/.claude-pod.toml if it exists

--- a/claude-pod.bash
+++ b/claude-pod.bash
@@ -218,7 +218,7 @@ mount_home_items() {
         case "$base" in
             .claude.json)
                 _args+=(-v "${item}:/mnt/.claude.json:ro") ;;
-            .claude|.config|.local)
+            .claude|.config|.local|.cache|.npm|.bun)
                 _args+=(-v "${item}:${item}") ;;
             *)
                 if [[ "$item" == "$cwd_top" || " $extra_rw " == *" $item "* ]]; then
@@ -272,6 +272,8 @@ build_base_args() {
     if ! is_macos && [[ -n "${HOMEBREW_PREFIX:-}" && -d "$HOMEBREW_PREFIX" ]]; then
         _base_args+=(-v "${HOMEBREW_PREFIX}:${HOMEBREW_PREFIX}:ro")
     fi
+    # Share /tmp for temp file exchange and package manager caches
+    _base_args+=(-v /tmp:/tmp)
 }
 
 # --- Subcommands ---

--- a/claude-pod.py
+++ b/claude-pod.py
@@ -209,7 +209,7 @@ def has_local_build_files() -> bool:
 _MACOS_SKIP = {".Trash", ".Trashes", "Library", ".local"}
 
 # Always rw directories
-_RW_DIRS = {".claude", ".config", ".local"}
+_RW_DIRS = {".claude", ".config", ".local", ".cache", ".npm", ".bun"}
 
 
 def _home_items() -> list[Path]:
@@ -301,6 +301,9 @@ def build_base_args(
         for font_dir in ("/usr/share/fonts", "/etc/fonts"):
             if Path(font_dir).is_dir():
                 args.extend(["-v", f"{font_dir}:{font_dir}:ro"])
+
+    # Share /tmp for temp file exchange and package manager caches
+    args.extend(["-v", "/tmp:/tmp"])
 
 
 # --- Subcommands ---

--- a/claude-pod.py
+++ b/claude-pod.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     sys.exit("error: Python 3.11+ is required (for tomllib)")
 
-VERSION = "0.8.2"
+VERSION = "0.9.0"
 IMAGE = "claude-pod:latest"
 CONTAINER_NAME_PREFIX = "claude-pod"
 HOST_OS = platform.system()


### PR DESCRIPTION
## Summary

- Mount `/tmp` from host (shared temp file exchange between host and container)
- Add `.cache`, `.npm`, `.bun` to the RW mount list (were mounted RO by default)
  - Covers: uv, pip, huggingface, playwright via `~/.cache`; npm via `~/.npm`; bun via `~/.bun`
- Applied to both bash and python implementations

## Test plan

- [ ] `claude-pod run` — verify `/tmp` is writable and shared with host
- [ ] `npm install` inside container — should use host cache, no EROFS errors
- [ ] `uv pip install` — should use host `~/.cache/uv`

Closes #47