### PR TITLE
Fix install SameFileError when home is symlinked

### DIFF
--- a/claude-pod.py
+++ b/claude-pod.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     sys.exit("error: Python 3.11+ is required (for tomllib)")
 
-VERSION = "0.9.0"
+VERSION = "0.9.1"
 IMAGE = "claude-pod:latest"
 CONTAINER_NAME_PREFIX = "claude-pod"
 HOST_OS = platform.system()

--- a/claude-pod.py
+++ b/claude-pod.py
@@ -559,7 +559,7 @@ def cmd_install(args: argparse.Namespace) -> None:
     script_path = Path(script_dir)
     if has_local_build_files():
         print(f"Installing from local source ({script_dir})...")
-        if str(script_path) != str(data_dir):
+        if not os.path.samefile(script_path, data_dir):
             for f in install_files:
                 src = script_path / f
                 if src.is_file():


### PR DESCRIPTION
## Summary
- `cmd_install` compared `script_path` and `data_dir` by string, which fails when the home directory is reached via different paths (e.g. `/workspace/home/user` vs `/home/user` through a symlink or bind mount)
- `shutil.copy2` then raises `SameFileError` trying to copy a file onto itself
- Fix: use `os.path.samefile()` which checks device + inode at the OS level

## Test plan
- [ ] Run `claude-pod install` on a machine where `$HOME` is symlinked or bind-mounted from a different path
- [ ] Run `claude-pod install` normally (non-symlinked home) to verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)