### PR TITLE
feat: add per-cache source dir knobs to fix btrfs cross-subvolume hardlink issue (closes #53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,28 @@ claude-pod shell                    # drop into a shell in the container
 
 ## Config
 
-Optional: `~/.config/claude-pod/config.toml`
+Optional global config: `~/.config/claude-pod/config.toml`  
+Optional per-project config: `.claude-pod.toml` in the project directory (merged with global; per-project wins on scalar keys)
 
 ```toml
 [defaults]
 notify_command = "curl -s -d \"Claude done in $WORKSPACE (exit $EXIT_CODE)\" https://ntfy.sh/my-topic"
 extra_volumes = ["/data/shared:/data/shared:ro"]
 extra_env = ["GITHUB_TOKEN"]
+
+[pod]
+# Per-cache source overrides — useful on btrfs multi-subvolume setups where
+# ~/.cache, ~/.npm, ~/.bun are on a different subvolume than ~/src.
+# uv/pnpm/bun hardlinks fail cross-subvolume (EXDEV) causing full ~5-7 GB venv copies.
+# Point these at paths on the same subvolume as your repos so hardlinks succeed.
+# Supports ~ and $HOME expansion. Directories are auto-created if missing.
+# See: https://github.com/xukai92/claude-pod/issues/53
+cache_source_dir = "~/src/.pod-cache"   # mounts as ~/.cache inside the pod
+npm_source_dir   = "~/src/.pod-npm"     # mounts as ~/.npm inside the pod
+bun_source_dir   = "~/src/.pod-bun"     # mounts as ~/.bun inside the pod
 ```
+
+If a source dir is set but empty while the corresponding host directory is non-empty, claude-pod prints a hint with the rsync command to migrate your existing cache — no data is moved automatically.
 
 ## Security model
 

--- a/claude-pod.py
+++ b/claude-pod.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     sys.exit("error: Python 3.11+ is required (for tomllib)")
 
-VERSION = "0.10.0"
+VERSION = "0.11.0"
 IMAGE = "claude-pod:latest"
 CONTAINER_NAME_PREFIX = "claude-pod"
 HOST_OS = platform.system()
@@ -241,11 +241,34 @@ def _home_items() -> list[Path]:
     return items
 
 
+# Config keys for per-directory source overrides: home dir name → (section, key)
+_DIR_OVERRIDE_CONFIGS: dict[str, tuple[str, str]] = {
+    ".cache": ("pod", "cache_source_dir"),
+    ".npm":   ("pod", "npm_source_dir"),
+    ".bun":   ("pod", "bun_source_dir"),
+}
+
+
+def resolve_dir_overrides(config: "Config") -> dict[str, Path]:
+    """Read per-directory source overrides from config and return {dir_name: resolved_src}."""
+    overrides: dict[str, Path] = {}
+    for dir_name, (section, key) in _DIR_OVERRIDE_CONFIGS.items():
+        val = config.get_merged(section, key)
+        if val:
+            src = Path(os.path.expandvars(val)).expanduser().resolve()
+            src.mkdir(parents=True, exist_ok=True)
+            overrides[dir_name] = src
+    return overrides
+
+
 def mount_home_items(
-    args: list[str], cwd: Path, extra_rw: set[str]
+    args: list[str], cwd: Path, extra_rw: set[str], dir_overrides: dict[str, Path] | None = None
 ) -> None:
     home_str = str(HOME)
     cwd_str = str(cwd)
+
+    if dir_overrides is None:
+        dir_overrides = {}
 
     # Determine cwd's top-level parent under HOME
     cwd_top = ""
@@ -253,6 +276,7 @@ def mount_home_items(
         rel = cwd_str[len(home_str) + 1 :]
         cwd_top = str(HOME / rel.split("/")[0])
 
+    handled: set[str] = set()
     for item in _home_items():
         name = item.name
         item_str = str(item)
@@ -262,12 +286,41 @@ def mount_home_items(
 
         if name == ".claude.json":
             args.extend(["-v", f"{item_str}:/mnt/.claude.json:ro"])
+        elif name in dir_overrides:
+            src = dir_overrides[name]
+            container_path = HOME / name
+            args.extend(["-v", f"{src}:{container_path}"])
+            print(f"claude-pod: mounting {name} from {src} (pod.{_DIR_OVERRIDE_CONFIGS[name][1]} override)", file=sys.stderr)
+            handled.add(name)
         elif name in _RW_DIRS:
             args.extend(["-v", f"{item_str}:{item_str}"])
         elif item_str == cwd_top or item_str in extra_rw:
             args.extend(["-v", f"{item_str}:{item_str}"])
         else:
             args.extend(["-v", f"{item_str}:{item_str}:ro"])
+
+    # Mount overrides for dirs that didn't exist on the host
+    for name, src in dir_overrides.items():
+        if name not in handled:
+            container_path = HOME / name
+            args.extend(["-v", f"{src}:{container_path}"])
+            print(f"claude-pod: mounting {name} from {src} (pod.{_DIR_OVERRIDE_CONFIGS[name][1]} override)", file=sys.stderr)
+
+    # Migration hint: for each override whose source is empty but host dir is non-empty
+    for name, src in dir_overrides.items():
+        host_dir = HOME / name
+        src_empty = not any(src.iterdir()) if src.exists() else True
+        host_has_content = host_dir.is_dir() and any(host_dir.iterdir())
+        if src_empty and host_has_content:
+            key = _DIR_OVERRIDE_CONFIGS[name][1]
+            print(
+                f"claude-pod: {key} is set but empty; existing ~/{name} contents won't be visible inside the pod.",
+                file=sys.stderr,
+            )
+            print(
+                f"            to migrate one-time: rsync -aH ~/{name}/ {src}/ && rm -rf ~/{name}/...",
+                file=sys.stderr,
+            )
 
 
 def cwd_needs_mount(cwd: Path) -> bool:
@@ -277,13 +330,13 @@ def cwd_needs_mount(cwd: Path) -> bool:
 
 
 def build_base_args(
-    args: list[str], cwd: Path, extra_rw: set[str]
+    args: list[str], cwd: Path, extra_rw: set[str], dir_overrides: dict[str, Path] | None = None
 ) -> None:
     args.extend(["--rm", "-w", str(cwd)])
     if not is_macos():
         args.extend(["--userns=keep-id", "--security-opt", "label=disable"])
 
-    mount_home_items(args, cwd, extra_rw)
+    mount_home_items(args, cwd, extra_rw, dir_overrides)
 
     if cwd_needs_mount(cwd):
         if is_macos():
@@ -374,8 +427,10 @@ def cmd_run(args: argparse.Namespace) -> None:
     writable_dirs.extend(d for d in config.get_array_merged("defaults", "writable_dirs") if d)
     extra_rw = set(writable_dirs)
 
+    dir_overrides = resolve_dir_overrides(config)
+
     podman_args = ["--name", f"{CONTAINER_NAME_PREFIX}-{int(time.time())}"]
-    build_base_args(podman_args, cwd, extra_rw)
+    build_base_args(podman_args, cwd, extra_rw, dir_overrides)
 
     if args.keep_groups:
         podman_args.extend(["--group-add", "keep-groups"])
@@ -457,8 +512,10 @@ def cmd_shell(args: argparse.Namespace) -> None:
     writable_dirs.extend(d for d in config.get_array_merged("defaults", "writable_dirs") if d)
     extra_rw = set(writable_dirs)
 
+    dir_overrides = resolve_dir_overrides(config)
+
     shell_args = ["-it"]
-    build_base_args(shell_args, cwd, extra_rw)
+    build_base_args(shell_args, cwd, extra_rw, dir_overrides)
 
     if args.max_memory:
         shell_args.append(f"--memory={args.max_memory}")

--- a/claude-pod.py
+++ b/claude-pod.py
@@ -249,14 +249,18 @@ _DIR_OVERRIDE_CONFIGS: dict[str, tuple[str, str]] = {
 }
 
 
-def resolve_dir_overrides(config: "Config") -> dict[str, Path]:
+def resolve_dir_overrides(config: "Config", create_dirs: bool = True) -> dict[str, Path]:
     """Read per-directory source overrides from config and return {dir_name: resolved_src}."""
     overrides: dict[str, Path] = {}
     for dir_name, (section, key) in _DIR_OVERRIDE_CONFIGS.items():
         val = config.get_merged(section, key)
         if val:
-            src = Path(os.path.expandvars(val)).expanduser().resolve()
-            src.mkdir(parents=True, exist_ok=True)
+            expanded = os.path.expandvars(val)
+            if "$" in expanded:
+                print(f"warning: pod.{key} contains an unresolved variable after expansion: {expanded!r}", file=sys.stderr)
+            src = Path(expanded).expanduser().resolve()
+            if create_dirs:
+                src.mkdir(parents=True, exist_ok=True)
             overrides[dir_name] = src
     return overrides
 
@@ -318,7 +322,11 @@ def mount_home_items(
                 file=sys.stderr,
             )
             print(
-                f"            to migrate one-time: rsync -aH ~/{name}/ {src}/ && rm -rf ~/{name}/...",
+                f"            to migrate one-time: rsync -aH ~/{name}/ {src}/",
+                file=sys.stderr,
+            )
+            print(
+                f"            then remove the dirs you no longer need from ~/{name}/ (e.g. rm -rf ~/{name}/uv ~/{name}/pip)",
                 file=sys.stderr,
             )
 
@@ -427,7 +435,7 @@ def cmd_run(args: argparse.Namespace) -> None:
     writable_dirs.extend(d for d in config.get_array_merged("defaults", "writable_dirs") if d)
     extra_rw = set(writable_dirs)
 
-    dir_overrides = resolve_dir_overrides(config)
+    dir_overrides = resolve_dir_overrides(config, create_dirs=not args.dry_run)
 
     podman_args = ["--name", f"{CONTAINER_NAME_PREFIX}-{int(time.time())}"]
     build_base_args(podman_args, cwd, extra_rw, dir_overrides)
@@ -512,7 +520,7 @@ def cmd_shell(args: argparse.Namespace) -> None:
     writable_dirs.extend(d for d in config.get_array_merged("defaults", "writable_dirs") if d)
     extra_rw = set(writable_dirs)
 
-    dir_overrides = resolve_dir_overrides(config)
+    dir_overrides = resolve_dir_overrides(config, create_dirs=not args.dry_run)
 
     shell_args = ["-it"]
     build_base_args(shell_args, cwd, extra_rw, dir_overrides)

--- a/test_python.sh
+++ b/test_python.sh
@@ -108,6 +108,30 @@ for name in "${!FIXTURE_CMDS[@]}"; do
     assert_eq "fixture $name" "$expected" "$actual"
 done
 
+# --- pod.cache_source_dir override ---
+echo ""
+echo "=== pod.cache_source_dir override ==="
+
+tmp_proj=$(mktemp -d)
+tmp_cache=$(mktemp -d)
+# shellcheck disable=SC2064
+trap "rm -rf '$tmp_proj' '$tmp_cache'" EXIT
+
+cat > "$tmp_proj/.claude-pod.toml" <<EOF
+[pod]
+cache_source_dir = "$tmp_cache"
+EOF
+
+# Run from the temp project dir so the project config is picked up
+cache_out=$(cd "$tmp_proj" && $PY run --dry-run 2>/dev/null)
+assert_contains "cache_source_dir override appears in mount args" "$cache_out" "$tmp_cache"
+# Container-side target must be the standard ~/.cache path
+assert_contains "cache_source_dir mounts to container ~/.cache" "$cache_out" "${HOME}/.cache"
+# Override path must not appear on the right-hand side of the volume spec
+# (i.e. source and dest differ — source is tmp_cache, dest is ~/.cache)
+cache_vol_spec="$tmp_cache:${HOME}/.cache"
+assert_contains "cache_source_dir volume spec has correct src:dst" "$cache_out" "$cache_vol_spec"
+
 # --- Summary ---
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="


### PR DESCRIPTION
## Summary

- Adds `pod.cache_source_dir`, `pod.npm_source_dir`, and `pod.bun_source_dir` config knobs in `~/.config/claude-pod/config.toml` (or `.claude-pod.toml` per-project)
- Each knob redirects the corresponding home-directory bind-mount (`~/.cache`, `~/.npm`, `~/.bun`) to a user-supplied host path, allowing it to live on the same btrfs subvolume as project repos
- Default behavior is fully unchanged — all three fields are optional; if unset, existing mounts apply
- Auto-`mkdir -p` the source if it doesn't exist; migration hint printed to stderr when source is empty but host dir has content

## Why

On btrfs hosts where `~/.cache` (and friends) are on a separate subvolume from `~/src`, the kernel rejects cross-subvolume hardlinks with `EXDEV`. `uv`, `pnpm`, and `bun` silently fall back to full copies — venvs balloon to 5-7 GB each. See [#53](https://github.com/xukai92/claude-pod/issues/53) for the full repro.

**Fix**: let users mount a host path that's on the same subvolume as their repos into the container's `~/.cache` / `~/.npm` / `~/.bun`. Hardlinks then succeed because source and target share a subvolume inside the container.

## Usage (btrfs subvolume example)

```toml
# ~/.config/claude-pod/config.toml
[pod]
cache_source_dir = "~/src/.pod-cache"   # mounts as ~/.cache inside the pod
npm_source_dir   = "~/src/.pod-npm"     # mounts as ~/.npm inside the pod
bun_source_dir   = "~/src/.pod-bun"     # mounts as ~/.bun inside the pod
```

## Changes

- `claude-pod.py`: adds `_DIR_OVERRIDE_CONFIGS`, `resolve_dir_overrides()`, generalizes `mount_home_items()` to handle per-dir overrides; `build_base_args`, `cmd_run`, `cmd_shell` pass overrides through
- `README.md`: documents all three knobs with the btrfs example and cross-ref to #53
- `test_python.sh`: adds `pod.cache_source_dir override` section verifying the mount args contain the correct `src:dst` volume spec
- Version: `0.10.0` → `0.11.0` (new feature)

## Test plan

- [ ] `./test_python.sh` — new `cache_source_dir override` section passes (3 assertions); pre-existing fixture failures are machine-specific and unrelated to this PR
- [ ] `claude-pod run --dry-run` with no config set — output unchanged from before
- [ ] `claude-pod run --dry-run` with `pod.cache_source_dir` set — output shows override volume spec; stderr shows the override notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)